### PR TITLE
fix: Drop use of `java.util.Base64` to support Android API level < 27

### DIFF
--- a/src/main/kotlin/tech/relaycorp/veraid/pki/Keys.kt
+++ b/src/main/kotlin/tech/relaycorp/veraid/pki/Keys.kt
@@ -2,13 +2,13 @@
 
 package tech.relaycorp.veraid.pki
 
+import org.bouncycastle.util.encoders.Base64
 import tech.relaycorp.veraid.KeyAlgorithm
 import tech.relaycorp.veraid.OrganisationKeySpec
 import tech.relaycorp.veraid.utils.Hash
 import tech.relaycorp.veraid.utils.hash
 import java.security.PublicKey
 import java.security.interfaces.RSAPublicKey
-import java.util.Base64
 
 private val SUPPORTED_RSA_MODULI = setOf(2048, 3072, 4096)
 
@@ -37,6 +37,6 @@ internal val PublicKey.orgKeySpec: OrganisationKeySpec
         val keyAlgorithm = rsaModulusKeyAlgorithmMap[modulus]!!
         val hash = rsaModulusHashMap[modulus]!!
         val digest = this.encoded.hash(hash)
-        val digestHex = Base64.getEncoder().encodeToString(digest)
+        val digestHex = Base64.toBase64String(digest)
         return OrganisationKeySpec(keyAlgorithm, digestHex)
     }

--- a/src/test/kotlin/tech/relaycorp/veraid/pki/KeysTest.kt
+++ b/src/test/kotlin/tech/relaycorp/veraid/pki/KeysTest.kt
@@ -2,6 +2,7 @@ package tech.relaycorp.veraid.pki
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import org.bouncycastle.util.encoders.Base64
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import tech.relaycorp.veraid.KeyAlgorithm
@@ -10,7 +11,6 @@ import tech.relaycorp.veraid.utils.BC_PROVIDER
 import tech.relaycorp.veraid.utils.Hash
 import tech.relaycorp.veraid.utils.hash
 import java.security.KeyPairGenerator
-import java.util.Base64
 
 class KeysTest {
     @Nested
@@ -68,6 +68,6 @@ class KeysTest {
             exception.message shouldBe "Key type (EC) is unsupported"
         }
 
-        private fun ByteArray.toBase64() = Base64.getEncoder().encodeToString(this)
+        private fun ByteArray.toBase64() = Base64.toBase64String(this)
     }
 }


### PR DESCRIPTION
Use BouncyCastle's encoder instead.
